### PR TITLE
Fix listening port to make the app run on heroku

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,8 +35,6 @@ app.get('/scrape', function (req, res) {
     })
 })
 
-app.listen('8081')
-
-console.log('Race to port 8081');
+app.listen(process.env.PORT || 8081, () => console.log('Race to port 8081'));
 
 exports = module.exports = app;


### PR DESCRIPTION
Heroku will "supply" custom port to run the app using the `process.env.PORT` in node.